### PR TITLE
Fix bug in path canonicaliation.

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -148,7 +148,7 @@ async function setup(versions) {
 
     if (typeof value === "object") {
       version = value.version;
-      location = path.join(process.cwd(), value.location);
+      location = path.resolve(process.cwd(), value.location);
     } else {
       version = value;
     }

--- a/test/index.js
+++ b/test/index.js
@@ -106,6 +106,28 @@ describe("faceoff", () => {
       });
 
       it("canonicalizes relative locations", async () => {
+        beforeEach(() => {
+          benchmark = new Faceoff({ currentVersion: { location: "." } });
+        });
+
+        let location;
+
+        benchmark.add("toRun", () => {}, {
+          setup: (module, val) => {
+            location = val;
+          }
+        });
+
+        await benchmark.run();
+
+        expect(location).to.equal(process.cwd());
+      });
+
+      it("accepts absolute paths for locations", async () => {
+        const absolutePath = process.cwd();
+
+        benchmark = new Faceoff({ currentVersion: { location: absolutePath } } );
+
         let location;
 
         benchmark.add("toRun", () => {}, {


### PR DESCRIPTION
If the configured location is absolute rather than relative, the path calculation was improperly concatenated instead of resolved.