### PR TITLE
Use foreground color instead of 'black' for metric bars that are

### DIFF
--- a/lib/util.js
+++ b/lib/util.js
@@ -202,7 +202,7 @@ function resultToString(result) {
     if (version.inconclusive) {
       color = "gray";
     } else if (version === baseline) {
-      color = "black";
+      color = "reset";
     } else if (version.opsSec > baseline.opsSec) {
       color = "green";
     } else {


### PR DESCRIPTION
in the default color.

Fixes #43