### PR TITLE
Fail on slow tests

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,11 @@
 # Important Changes
 
+## 1.3.0
+
+ - Faceoff now scans for and enumerates inconclusive tests via t-test
+ - More compact display of summary data, for better reading comprehension, particularly in CI
+ - You can now apply default options across all suites
+
 ## 1.2.0
 
  - You can now set default benchmark options on suites, improving ergonomics for nested suites with

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,10 @@
 # Important Changes
 
+## 1.4.0 (under development)
+
+ - 'Slow Test' criteria is now configurable
+ - Runs can now optionally fail on regressions over a threshold
+
 ## 1.3.0
 
  - Faceoff now scans for and enumerates inconclusive tests via t-test

--- a/README.md
+++ b/README.md
@@ -154,6 +154,8 @@ benchmark.suite('util',
   }
 );
 
+await benchmark.run({ output: "./output/benchmark-results.json" });
+
 ```
 
 ### benchmark.json file format

--- a/README.md
+++ b/README.md
@@ -110,7 +110,7 @@ The convention used is that the first version provided is the baseline, and the 
 version under test. Any entries between first and last are reference versions or branches to detect
 if the code under test has undone any improvements added in recent PRs.
 
-```
+```javascript
 import { createRequire } from 'node:module';
 import Path from 'path';
 
@@ -154,7 +154,7 @@ benchmark.suite('util',
   }
 );
 
-await benchmark.run({ output: "./output/benchmark-results.json" });
+await benchmark.run({ output: "./output/benchmark-results.json", slow: 0.94 });
 
 ```
 
@@ -240,17 +240,30 @@ until at least 2.0:
 
 ### Inconclusive Tests
 
-Every test run has noise. When a test has a lot of jitter in it, the average time per run does not prove that one case is
-consistently 10% faster than another. A Statistical Analysis called the t-test compares two sets of
-samples against each other to determine if the spread of values indicated a pattern or just noise - 
-Whether the results are significant or not.
+Every test run has noise. When a test has a lot of jitter in it, the average time per run does not
+prove that one case is consistently 10% faster than another. A Statistical Analysis called the
+t-test compares two sets of samples against each other to determine if the spread of values
+indicated a pattern or just noise - Whether the results are significant or not.
 
-The problem is that Faceoff presents an arbitrary number of versions and invites the user to 
-compare them all against each other. As far as we are aware, the transitive property does not 
-necessarily apply to significance tests. If two results are significant to a third, that does not mean they are significant in relationship to
-each other.
+The problem is that Faceoff presents an arbitrary number of versions and invites the user to
+compare them all against each other. As far as we are aware, the transitive property does not
+necessarily apply to significance tests. If two results are significant to a third, that does not
+mean they are significant in relationship to each other.
 
 We report a test as slow if the current (subject) version is slower than the fastest version by 5%,
+
+### Slow Tests
+
+Tests which are conclusive and show a greater than 5% reduction in speed are flagged as Slow. You
+can optionally fail the run if too many tests show a slowdown.
+
+```javascript
+await benchmark.run({ success: {
+    threshold: 1 // Fail on two or more slow results
+  }
+});
+
+```
 
 #### Parsing advice
 

--- a/examples/prom-client.js
+++ b/examples/prom-client.js
@@ -71,4 +71,9 @@ benchmark.suite('util', (suite) => {
   );
 });
 
-await (await benchmark.run()).outputResults();
+await benchmark.run(
+  {
+    output: "./output/benchmark-results/prom-client.json",
+    slow: 0.93
+  }
+);

--- a/examples/prom-client.js
+++ b/examples/prom-client.js
@@ -74,6 +74,7 @@ benchmark.suite('util', (suite) => {
 await benchmark.run(
   {
     output: "./output/benchmark-results/prom-client.json",
-    slow: 0.93
+    slow: 0.93,
+    success: { }
   }
 );

--- a/lib/index.js
+++ b/lib/index.js
@@ -11,6 +11,12 @@ import Util from "./util.js";
  */
 
 /**
+ * @typedef {Object} RunOptions
+ * @property {number=0.95} slow  - threshold for reporting slowdowns
+ * @property {string=} output - output file for the JSON version of the data
+ */
+
+/**
  * Callback function for adding benchmarks to a Faceoff suite
  *
  * @function SuiteCallback
@@ -22,7 +28,7 @@ import Util from "./util.js";
  * @class Faceoff
  */
 class Faceoff {
-  #lastResults = undefined;
+  #summary = undefined;
 
   /**
    * @param {object} versions
@@ -103,9 +109,10 @@ class Faceoff {
   /**
    * Run the benchmarks.
    *
+   * @param options {RunOptions}
    * @returns {Promise<Faceoff>}
    */
-  async run() {
+  async run(options = {}) {
     this.modules = await setup(this.versions);
 
     const results = [];
@@ -114,7 +121,13 @@ class Faceoff {
       results.push(await suite.run());
     }
 
-    this.#lastResults = Util.chartResults(results);
+    const limit = options.slow ?? Number.MAX_SAFE_INTEGER;
+
+    this.#summary = Util.chartResults(results, { limit });
+
+    if (options.output !== undefined) {
+      await this.outputResults(options.output);
+    }
 
     return this;
   }
@@ -125,7 +138,7 @@ class Faceoff {
    * @returns {Promise<void>}
    */
   async outputResults(filename = "./output/benchmark-results/benchmark.json") {
-    const json = JSON.stringify(this.#lastResults ?? {}, undefined, 2);
+    const json = JSON.stringify(this.#summary ?? {}, undefined, 2);
     const basename = path.dirname(filename);
     await fs.mkdir(basename, { recursive: true });
     await fs.writeFile(filename, json, { encoding: "utf8" });

--- a/lib/index.js
+++ b/lib/index.js
@@ -12,8 +12,14 @@ import Util from "./util.js";
 
 /**
  * @typedef {Object} RunOptions
- * @property {number=0.95} slow  - threshold for reporting slowdowns
  * @property {string=} output - output file for the JSON version of the data
+ * @property {number=0.95} slow  - threshold for reporting slowdowns
+ * @property {SuccessCriteria=} success - success criteria for the build
+ */
+
+/**
+ * @typedef {Object} SuccessCriteria
+ * @property {number=0} threshold - number of regressions allowed before triggering a build failure
  */
 
 /**
@@ -129,6 +135,18 @@ class Faceoff {
       await this.outputResults(options.output);
     }
 
+    const successCriteria = options.success;
+
+    if (successCriteria !== undefined) {
+      const max = successCriteria.threshold ?? 0;
+      const failures = Util.findSlow(this.#summary, options.slow);
+
+      if (Object.keys(failures).length > max) {
+        console.error(`Success criteria unmet. ${max === 0 ? "No" : max} slow results allowed.`);
+        console.error("Please refer to 'Performance Regressions' section in the output.");
+        process.exit(1);
+      }
+    }
     return this;
   }
 

--- a/lib/util.js
+++ b/lib/util.js
@@ -122,17 +122,23 @@ function findInconclusive(summary = {}) {
 /**
  * Chart the results and return the analysis
  * @param results
+ * @param {object} displayOptions - options for output formatting
  * @returns {{}}
  */
-function chartResults(results) {
+function chartResults(results, displayOptions = {}) {
   const summary = analyze(results);
 
-  console.log(toString(summary));
+  console.log(toString(summary, displayOptions));
 
   return summary;
 }
 
-function toString(summary) {
+/**
+ * @param summary
+ * @param {object} options - options for output formatting
+ * @returns {string}
+ */
+function toString(summary, options = {}) {
   let asString = "\n";
 
   asString += report.toChart([], { printHeader: true });
@@ -166,7 +172,7 @@ function toString(summary) {
     asString += "\n";
   }
 
-  const slow = findSlow(summary);
+  const slow = findSlow(summary, options?.limit);
 
   if (isEmpty(slow)) {
     asString += styleText(["green", "bold"], "No significant regressions found.");

--- a/lib/util.js
+++ b/lib/util.js
@@ -18,7 +18,7 @@ const numberFormat = Intl.NumberFormat(undefined, {
 
 /**
  * Split suite name out of the test name
- * @param testName
+ * @param {string} testName
  * @returns {*}
  */
 function headingName(testName) {
@@ -34,8 +34,8 @@ function headingName(testName) {
  * Util.install("@babel/core@latest", "@babel/core")
  * ```
  *
- * @param versionString {string} logical name, starting with string suitable for 'import'
- * @param packageSemver {string|module} a string suitable for 'npm install', or the module
+ * @param {string} versionString - logical name, starting with string suitable for 'import'
+ * @param {string|module} packageSemver - a string suitable for 'npm install', or the module
  * @returns {Promise<*>}
  */
 async function install(versionString, packageSemver) {
@@ -58,8 +58,8 @@ async function install(versionString, packageSemver) {
 
 /**
  * Execute a command and await the results
- * @param command {string}
- * @param opts {object}
+ * @param {string} command
+ * @param {object} opts
  * @returns {Promise<string>}
  */
 async function asyncExec(command, opts) {
@@ -76,10 +76,11 @@ async function asyncExec(command, opts) {
 
 /**
  * Filter for performance regressions.
- * @param summary
- * @returns {O ject}
+ * @param {object} summary - results summary for analysis
+ * @param {number} [limit=0.95] - threshold for reporting errors
+ * @returns {object}
  */
-function findSlow(summary = {}) {
+function findSlow(summary = {}, limit = 0.95) {
   const slow = {};
 
   for (const name of Object.keys(summary)) {
@@ -93,9 +94,9 @@ function findSlow(summary = {}) {
     // This handles intermediate versions being faster than the baseline
     if (subject.fastest !== true) {
       const fastest = result.find(entry => entry.fastest === true);
-      const slower = fastest.opsSec / subject.opsSec;
+      const slower = subject.opsSec / fastest.opsSec ;
 
-      if (slower >= 1.05) {
+      if (slower <= limit) {
         slow[name] = result;
       }
     }
@@ -293,7 +294,7 @@ function analyzeOne(result) {
       if (significant) {
         count++;
       }
-    };
+    }
 
     return {
       ...data,
@@ -310,6 +311,10 @@ function analyzeOne(result) {
   return analysis;
 }
 
+/**
+ * @param results {object}
+ * @returns {object}
+ */
 function analyze(results) {
   const reply = {};
 

--- a/test/unit/util.js
+++ b/test/unit/util.js
@@ -99,6 +99,36 @@ describe("Util", () => {
       expect(Object.keys(actual)).to.have.length(1);
     });
 
+    it("has a configurable cutoff", () => {
+      let input = [
+        {
+          name: 'foo ⇒ a',
+          iterations: 200,
+          fastest: true,
+          histogram: {
+            "samples": 11,
+            "min": 1966.0067526089626,
+            "max": 2096.9027705175117,
+          },
+          "opsSec": 1989.98778631387,
+        },
+        {
+          name: 'foo ⇒ b',
+          iterations: 200,
+          slowest: true,
+          histogram: {
+            "samples": 12,
+            "min": 1766.0067526089626,
+            "max": 2096.9027705175117,
+          },
+          "opsSec": 1801.98778631387,
+        },
+      ];
+
+      let actual = Util.findSlow([input], 0.9);
+      expect(Object.keys(actual)).to.be.empty;
+    });
+
     it("filters out fast tests", () => {
       let input = [
         {


### PR DESCRIPTION
Note: This PR also slightly changes the cutoff for slow tests. 

Previously we were dividing the baseline by the test in order to look for anything over 1.05, but that means that we are not reporting on 5% slowdowns, but on 4.66% slowdowns. This can be seen as some "0.95x" results being flagged while others passed, due to rounding behavior.
